### PR TITLE
feature/#5: ClubMenuItem 분리 후 entries 적용, contentDescprition 하드코딩 대신 stringResource 적용

### DIFF
--- a/app/src/main/java/org/sopt/holix/presentation/club_detail_home/ClubDetailHomeRoute.kt
+++ b/app/src/main/java/org/sopt/holix/presentation/club_detail_home/ClubDetailHomeRoute.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Divider
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -43,20 +40,7 @@ import org.sopt.holix.core.util.UiState
 import org.sopt.holix.core.util.noRippleClickable
 import org.sopt.holix.domain.model.DummyUser
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.ui.input.pointer.motionEventSpy
 
-enum class ClubMenuItem(val label: String, @DrawableRes val iconRes: Int) {
-    MEETING("모임", R.drawable.ic_club_category_4),
-    MENTORING("멘토링", R.drawable.ic_club_category_1),
-    CLASS("클래스", R.drawable.ic_club_category_2),
-    QUIZ("퀴즈", R.drawable.ic_club_category_3);
-
-    companion object {
-        val items get() = entries
-    }
-}
 
 @Composable
 fun ClubDetailHomeRoute(
@@ -165,7 +149,7 @@ fun ClubDetailHomeScreen(
                     ) {
                         AsyncImage(
                             model = R.drawable.img_club_main_and,
-                            contentDescription = "배너 이미지",
+                            contentDescription = stringResource(R.string.description_banner),
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize()
                         )
@@ -215,7 +199,7 @@ fun ClubDetailHomeScreen(
                             ) {
                                 Icon(
                                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_chatting_menu_4),
-                                    contentDescription = "",
+                                    contentDescription = stringResource(R.string.description_member),
                                     tint = HolixTheme.colors.gray04
                                 )
                                 Spacer(modifier = Modifier.width(4.dp))
@@ -243,7 +227,7 @@ fun ClubDetailHomeScreen(
                                 ) {
                                     Icon(
                                         imageVector = ImageVector.vectorResource(id = R.drawable.ic_speaker),
-                                        contentDescription = "확성기 아이콘",
+                                        contentDescription = stringResource(R.string.description_speaker),
                                         tint = Color.Unspecified
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
@@ -255,7 +239,7 @@ fun ClubDetailHomeScreen(
                                 }
                                 Icon(
                                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_right_gray),
-                                    contentDescription = "오른쪽 화살표",
+                                    contentDescription = stringResource(R.string.description_arrow_right),
                                     tint = Color.Unspecified,
                                     modifier = Modifier.padding(end = 11.dp)
                                 )
@@ -291,7 +275,7 @@ fun ClubDetailHomeScreen(
                                         Spacer(modifier = Modifier.height(13.dp))
                                         Icon(
                                             painter = painterResource(id = item.iconRes),
-                                            contentDescription = item.label,
+                                            contentDescription = stringResource(id = item.labelRes),
                                             tint = HolixTheme.colors.gray06
                                         )
                                         Spacer(modifier = Modifier.height(9.dp))
@@ -332,7 +316,7 @@ fun ClubDetailHomeScreen(
                         ) {
                             Image(
                                 painter = painterResource(id = R.drawable.speech_bubble_and),
-                                contentDescription = "채팅 안내 말풍선",
+                                contentDescription = stringResource(R.string.description_chat_bubble),
                                 modifier = Modifier
                                     .padding(start = 16.dp)
                                     .align(Alignment.Start)
@@ -410,12 +394,12 @@ fun ClubDetailTopAppBar(
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_left_white),
-                contentDescription = "뒤로가기",
+                contentDescription = stringResource(R.string.description_back),
                 tint = Color.White,
                 modifier = Modifier.noRippleClickable { navigateUp() })
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_search_white),
-                contentDescription = "검색",
+                contentDescription = stringResource(R.string.description_search),
                 tint = Color.White,
                 modifier = Modifier.noRippleClickable { onSearchClick() })
         }

--- a/app/src/main/java/org/sopt/holix/presentation/club_detail_home/ClubMenuItem.kt
+++ b/app/src/main/java/org/sopt/holix/presentation/club_detail_home/ClubMenuItem.kt
@@ -1,0 +1,20 @@
+package org.sopt.holix.presentation.club_detail_home
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import org.sopt.holix.R
+
+enum class ClubMenuItem(
+    @StringRes val labelRes: Int,
+    val label: String,
+    @DrawableRes val iconRes: Int
+) {
+    MEETING(R.string.description_meeting, "모임", R.drawable.ic_club_category_4),
+    MENTORING(R.string.description_mentoring, "멘토링", R.drawable.ic_club_category_1),
+    CLASS(R.string.description_class, "클래스", R.drawable.ic_club_category_2),
+    QUIZ(R.string.description_quiz, "퀴즈", R.drawable.ic_club_category_3);
+
+    companion object {
+        val items get() = entries
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,15 @@
     <string name="profile">프로필</string>
     <string name="empty_string">데이터가 없습니다.</string>
     <string name="loading_string">로딩 중...</string>
+    <string name="description_banner">배너 이미지</string>
+    <string name="description_speaker">공지 아이콘</string>
+    <string name="description_arrow_right">오른쪽 화살표</string>
+    <string name="description_back">뒤로가기</string>
+    <string name="description_search">검색</string>
+    <string name="description_chat_bubble">채팅 안내 말풍선</string>
+    <string name="description_member">멤버 아이콘</string>
+    <string name="description_meeting">모임 아이콘</string>
+    <string name="description_mentoring">멘토링 아이콘</string>
+    <string name="description_class">클래스 아이콘</string>
+    <string name="description_quiz">퀴즈 아이콘</string>
 </resources>


### PR DESCRIPTION

## ISSUE
- closed #이슈번호

## ❗ WORK DESCRIPTION
- 까먹고 머지된 브랜치에 푸쉬해서 다시 올리는 pr

## 📸 SCREENSHOT
<img src="" width="300" />

BEFORE | AFTER
-- | --
<video src="" width="300"></video> | <video src="" width="300"></video>
<img src="" width="300" /> | <img src="" width="300" />

## 📢 TO REVIEWERS
- 리뷰어에게 전달해야 하는 말